### PR TITLE
Suppress debconf warning during apt-get install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu:disco
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
+    # https://github.com/phusion/baseimage-docker/issues/319
+    apt-get --yes install apt-utils 2>&1 | grep -v "debconf: delaying package configuration, since apt-utils is not installed" && \
     apt-get --no-install-recommends --yes install firefox=68\* dumb-init socat fontconfig && \
     groupadd firefox && \
     useradd --create-home --gid firefox firefox && \


### PR DESCRIPTION
Suppresses "debconf: delaying package configuration, since apt-utils is not installed" warning during apt-get install.

Fixes #2.